### PR TITLE
Add support for trusted publishing with git hub action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,12 +27,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install poetry==2.1.1 'poetry-dynamic-versioning[plugin]'
 
-      - name: Configure poetry
-        env:
-          pypi_token: ${{ secrets.PyPI_TOKEN }}
-        run: poetry config pypi-token.pypi $pypi_token
-
-      - name: Build and publish
+      - name: Build
         run: |
           poetry build
-          poetry publish
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- insertion marker -->
+## [v0.13.4](https://github.com/tradewelltech/protarrow/releases/tag/v0.13.4) - 2025-04-16
+
+<small>[Compare with v0.13.3](https://github.com/tradewelltech/protarrow/compare/v0.13.3...v0.13.4)</small>
+
+### Added
+
+- Add support for trusted publishing with git hub action ([9647853](https://github.com/tradewelltech/protarrow/commit/96478538178c27a4b56948cea1d956b9d0cbd3d3) by aandres3).
+
 ## [v0.13.3](https://github.com/tradewelltech/protarrow/releases/tag/v0.13.3) - 2025-04-15
 
 <small>[Compare with v0.13.2](https://github.com/tradewelltech/protarrow/compare/v0.13.2...v0.13.3)</small>


### PR DESCRIPTION
This means we no longer need a pypi token, as pypi authorise `.github/workflows/publish.yaml` to publish.